### PR TITLE
Add typings to conditional exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixes [#5](https://github.com/compulim/use-read-alert/issues/5), exports typings through conditional exports, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/compulim/use-read-alert/pull/6)
+
 ### Changed
 
 - Bump dependencies, by [@compulim](https://github.com/compulim), in PR [#4](https://github.com/compulim/use-read-alert/pull/4)

--- a/packages/use-read-alert/package.json
+++ b/packages/use-read-alert/package.json
@@ -8,15 +8,18 @@
   "exports": {
     ".": {
       "import": "./lib/esmodules/index.js",
-      "require": "./lib/commonjs/index.js"
+      "require": "./lib/commonjs/index.js",
+      "types": "./lib/types/index.d.ts"
     },
     "./UseReadAlertProvider": {
       "import": "./lib/esmodules/UseReadAlertProvider.js",
-      "require": "./lib/commonjs/UseReadAlertProvider.js"
+      "require": "./lib/commonjs/UseReadAlertProvider.js",
+      "types": "./lib/types/UseReadAlertProvider.d.ts"
     },
     "./useReadAlert": {
       "import": "./lib/esmodules/useReadAlert.js",
-      "require": "./lib/commonjs/useReadAlert.js"
+      "require": "./lib/commonjs/useReadAlert.js",
+      "types": "./lib/types/useReadAlert.d.ts"
     }
   },
   "main": "./lib/commonjs/index.js",


### PR DESCRIPTION
## Changelog

> Please copy and paste new entries from `CHANGELOG.md` here.

### Fixed

- Fixes [#5](https://github.com/compulim/use-read-alert/issues/5), exports typings through conditional exports, by [@compulim](https://github.com/compulim), in PR [#6](https://github.com/compulim/use-read-alert/pull/6)

## Specific changes

> Please list each individual specific change in this pull request.

- Add `types` to conditional exports